### PR TITLE
terminate called after throwing an instance of 'rclcpp::ParameterTypeException' error is removed. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,21 +16,25 @@ include_directories(include ${BOOST_INCLUDE_DIRS})
 
 add_library(serial_ros2 src/serial_ros2.cpp)
 
+
 ament_target_dependencies(serial_ros2 rclcpp)
 ament_export_targets(serial_ros2 HAS_LIBRARY_TARGET)
 
 
+add_executable(serial_ros2_test src/serial_ros2_test.cpp)
+target_link_libraries(serial_ros2_test ${catkin_LIBRARES})
+ament_target_dependencies(serial_ros2_test rclcpp)
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # uncomment the line when this package is not in a git repo
-  #set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
+install(TARGETS
+        serial_ros2_test
+        DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY
+        launch
+        config
+        DESTINATION share/${PROJECT_NAME}/
+)
 
 install(TARGETS
   serial_ros2

--- a/include/serial_ros2/serial_ros2_test.h
+++ b/include/serial_ros2/serial_ros2_test.h
@@ -26,6 +26,12 @@ class SerialROS: public rclcpp::Node
 
         int _baudrate;
 
+        int _character_size;
+
+        string _readed_data = "";
+
+        string _data_to_be_written = "";
+
         Serial *_serial_pointer;
 
 };  

--- a/include/serial_ros2/serial_ros2_test.h
+++ b/include/serial_ros2/serial_ros2_test.h
@@ -3,6 +3,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <serial_ros2/serial_ros2.h>
+#include "../../src/serial_ros2.cpp"
 
 
 using namespace std;

--- a/launch/serial_ros2_test.launch.py
+++ b/launch/serial_ros2_test.launch.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import os
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='serial_ros2',
+            executable='serial_ros2_test',
+            name='serial_ros2_test_node',
+            output='screen',
+            parameters=[os.path.join(
+                get_package_share_directory('serial_ros2'), 
+                'config', 'config.yaml')])
+    ])

--- a/src/serial_ros2_test.cpp
+++ b/src/serial_ros2_test.cpp
@@ -8,7 +8,7 @@ Node("serial_ros_node")
     _write_timer = this->create_wall_timer(10ms, std::bind(&SerialROS::writeToSerailPort, this));
 
     declare_parameter("port_name", "/dev/ttyACM0");
-    declare_parameter("baudrate", "19200");
+    declare_parameter("baudrate", 19200);
     declare_parameter("character_size", 150);
 
     _port_name = this->get_parameter("port_name").as_string();
@@ -21,6 +21,9 @@ Node("serial_ros_node")
 
     Serial serial = Serial("/dev/ttyACM0", B19200);
     _serial_pointer = &serial;
+    
+    _serial_pointer->openSerialPort();
+    _serial_pointer->prepareSerialPort();
 }
 
 

--- a/src/serial_ros2_test.cpp
+++ b/src/serial_ros2_test.cpp
@@ -24,6 +24,11 @@ Node("serial_ros_node")
 }
 
 
+SerialROS::~SerialROS()
+{
+
+}
+
 void SerialROS::readFromSerialPort(void)
 {
     _readed_data = _serial_pointer->readSerialPort(_character_size);

--- a/src/serial_ros2_test.cpp
+++ b/src/serial_ros2_test.cpp
@@ -9,12 +9,15 @@ Node("serial_ros_node")
 
     declare_parameter("port_name", "/dev/ttyACM0");
     declare_parameter("baudrate", "19200");
+    declare_parameter("character_size", 150);
 
     _port_name = this->get_parameter("port_name").as_string();
     _baudrate = this->get_parameter("baudrate").as_int();
+    _character_size = this->get_parameter("character_size").as_int();
 
     RCLCPP_INFO_STREAM(this->get_logger(), "Serial Port Name: " << _port_name);
     RCLCPP_INFO_STREAM(this->get_logger(), "Serial Baudrate: " << _baudrate);
+    RCLCPP_INFO_STREAM(this->get_logger(), "Readed character size as byte: " << _character_size);
 
     Serial serial = Serial("/dev/ttyACM0", B19200);
     _serial_pointer = &serial;
@@ -23,13 +26,15 @@ Node("serial_ros_node")
 
 void SerialROS::readFromSerialPort(void)
 {
-
+    _readed_data = _serial_pointer->readSerialPort(_character_size);
+    RCLCPP_INFO_STREAM(this->get_logger(), "Readed Data From Serial: " << _readed_data);
 }
 
 
 void SerialROS::writeToSerailPort(void)
 {
-
+    _data_to_be_written = "Hello From ROS2 Serial...";
+    _serial_pointer->writeSerialPort(_data_to_be_written);
 }
 
 


### PR DESCRIPTION
Errors removed from test code. Now user can start this package with "ros2 run serial_ros2 serial_ros2_test" 